### PR TITLE
Add heading parsing to Markdown utility

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -9,6 +9,8 @@ export function fetchData(url) {
 
 export function parseMarkdown(text = '') {
     return text
+        .replace(/^##\s+(.+)$/gm, '<h2>$1</h2>')
+        .replace(/^#\s+(.+)$/gm, '<h1>$1</h1>')
         .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
         .replace(/\*(.+?)\*/g, '<em>$1</em>')
         .replace(/`(.+?)`/g, '<code>$1</code>')


### PR DESCRIPTION
## Summary
- update `parseMarkdown` utility to parse heading syntax

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856b43b49dc833285aef851bec46838